### PR TITLE
Update java sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,26 @@ Dockerized CLI application which allows to automatically sync different resource
 ##### Download
 
    ```bash
-docker pull commercetools/commercetools-project-sync:1.0.0
+docker pull commercetools/commercetools-project-sync:1.1.0
    ```
 ##### Run
 
-   ```bash
-docker run commercetools/commercetools-project-sync:1.0.0
-   ```
+```bash
+docker run \
+-e SOURCE_PROJECT_KEY=xxxx \
+-e SOURCE_CLIENT_ID=xxxx \
+-e SOURCE_CLIENT_SECRET=xxxx \
+-e TARGET_PROJECT_KEY=xxxx \
+-e TARGET_CLIENT_ID=xxxx \
+-e TARGET_CLIENT_SECRET=xxxx \
+commercetools/commercetools-project-sync:1.1.0 -s all
+```
   
 
 ### Examples   
  - To run the all sync modules from a source project to a target project
    ```bash
-   docker run commercetools/commercetools-project-sync:1.0.0 -s all
+   docker run commercetools/commercetools-project-sync:1.1.0 -s all
    ```
    This will run the following sync modules in the given order:
  1. `Type` Sync and `ProductType` Sync in parallel.
@@ -79,27 +86,27 @@ docker run commercetools/commercetools-project-sync:1.0.0
 
  - To run the type sync
    ```bash
-   docker run commercetools/commercetools-project-sync:1.0.0 -s types
+   docker run commercetools/commercetools-project-sync:1.1.0 -s types
    ```  
 
  - To run the productType sync
    ```bash
-   docker run commercetools/commercetools-project-sync:1.0.0 -s productTypes
+   docker run commercetools/commercetools-project-sync:1.1.0 -s productTypes
    ```  
     
 - To run the category sync
    ```bash
-   docker run commercetools/commercetools-project-sync:1.0.0 -s categories
+   docker run commercetools/commercetools-project-sync:1.1.0 -s categories
    ```  
    
 - To run the product sync
    ```bash
-   docker run commercetools/commercetools-project-sync:1.0.0 -s products
+   docker run commercetools/commercetools-project-sync:1.1.0 -s products
    ```  
     
 - To run the inventoryEntry sync
    ```bash
-   docker run commercetools/commercetools-project-sync:1.0.0 -s inventoryEntries
+   docker run commercetools/commercetools-project-sync:1.1.0 -s inventoryEntries
    ```     
    
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -36,3 +36,16 @@ are breaking changes. If there are, then a migration guide should be provided.
  - **Category Sync** - First version of the tool.
  - **Product Sync** - First version of the tool.
  -->
+ 
+ ### 1.1.0 - Jan 16, 2019
+  [Commits](https://github.com/commercetools/commercetools-project-sync/commits/1.1.0) |
+  [Docker Image](https://hub.docker.com/r/commercetools/commercetools-project-sync/)
+   
+  **Enhancements** (1)
+   - **Common** - Bump commercetools-sync-java library to `1.1.1`.
+ 
+ ### 1.0.0 - Jan 11, 2019
+ [Commits](https://github.com/commercetools/commercetools-project-sync/commits/1.0.0) |
+ [Docker Image](https://hub.docker.com/r/commercetools/commercetools-project-sync/)
+  
+  **First public release**.

--- a/gradle-scripts/dependencies.gradle
+++ b/gradle-scripts/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     pmdVersion = '5.6.1'
     jacocoVersion = '0.7.9'
     findbugsVersion = '3.0.1'
-    commercetoolsSyncJava='1.1.0'
+    commercetoolsSyncJava='1.1.1'
     apacheCliVersion = '1.4'
     jupiterApiVersion = '5.3.2'
 }


### PR DESCRIPTION
- Bump commercetools-sync-java dep: https://github.com/commercetools/commercetools-project-sync/compare/update-java-sync?expand=1#diff-771e2d81321cde33fec338d366924359R10
- Prepare for release 1.1.0
- Also addresses https://github.com/commercetools/commercetools-project-sync/issues/19