### PR TITLE
Add TaxCategorySyncer and TaxCategorySyncerTest

### DIFF
--- a/src/main/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncer.java
+++ b/src/main/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncer.java
@@ -1,0 +1,101 @@
+package com.commercetools.project.sync.taxcategory;
+
+import com.commercetools.project.sync.Syncer;
+import com.commercetools.project.sync.service.CustomObjectService;
+import com.commercetools.project.sync.service.impl.CustomObjectServiceImpl;
+import com.commercetools.sync.taxcategories.TaxCategorySync;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptions;
+import com.commercetools.sync.taxcategories.TaxCategorySyncOptionsBuilder;
+import com.commercetools.sync.taxcategories.helpers.TaxCategorySyncStatistics;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import io.sphere.sdk.taxcategories.TaxRate;
+import io.sphere.sdk.taxcategories.TaxRateDraft;
+import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class TaxCategorySyncer
+    extends Syncer<
+        TaxCategory,
+        TaxCategoryDraft,
+        TaxCategorySyncStatistics,
+        TaxCategorySyncOptions,
+        TaxCategoryQuery,
+        TaxCategorySync> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TaxCategorySyncer.class);
+
+  /** Instantiates a {@link Syncer} instance. */
+  private TaxCategorySyncer(
+      @Nonnull final TaxCategorySync taxCategorySync,
+      @Nonnull final SphereClient sourceClient,
+      @Nonnull final SphereClient targetClient,
+      @Nonnull final CustomObjectService customObjectService,
+      @Nonnull final Clock clock) {
+    super(taxCategorySync, sourceClient, targetClient, customObjectService, clock);
+  }
+
+  @Nonnull
+  public static TaxCategorySyncer of(
+      @Nonnull final SphereClient sourceClient,
+      @Nonnull final SphereClient targetClient,
+      @Nonnull final Clock clock) {
+    final TaxCategorySyncOptions syncOptions =
+        TaxCategorySyncOptionsBuilder.of(targetClient)
+            .errorCallback(LOGGER::error)
+            .warningCallback(LOGGER::warn)
+            .build();
+
+    final TaxCategorySync taxCategorySync = new TaxCategorySync(syncOptions);
+    final CustomObjectService customObjectService = new CustomObjectServiceImpl(targetClient);
+    return new TaxCategorySyncer(
+        taxCategorySync, sourceClient, targetClient, customObjectService, clock);
+  }
+
+  @Override
+  @Nonnull
+  protected CompletionStage<List<TaxCategoryDraft>> transform(
+      @Nonnull final List<TaxCategory> page) {
+    return CompletableFuture.completedFuture(
+        page.stream()
+            .map(TaxCategorySyncer::convertTaxCaetegoryToTaxCategoryDraft)
+            .collect(Collectors.toList()));
+  }
+
+  @Nonnull
+  private static TaxCategoryDraft convertTaxCaetegoryToTaxCategoryDraft(
+      @Nonnull final TaxCategory taxCategory) {
+    List<TaxRateDraft> taxRateDrafts = null;
+    if (taxCategory.getTaxRates() != null) {
+      taxRateDrafts = convertTaxRateToTaxRateDraft(taxCategory.getTaxRates());
+    }
+    return TaxCategoryDraftBuilder.of(
+            taxCategory.getName(), taxRateDrafts, taxCategory.getDescription())
+        .build();
+  }
+
+  @Nonnull
+  private static List<TaxRateDraft> convertTaxRateToTaxRateDraft(
+      @Nonnull final List<TaxRate> taxRates) {
+    return taxRates
+        .stream()
+        .map(taxRate -> TaxRateDraftBuilder.of(taxRate).build())
+        .collect(Collectors.toList());
+  }
+
+  @Nonnull
+  @Override
+  protected TaxCategoryQuery getQuery() {
+    return TaxCategoryQuery.of();
+  }
+}

--- a/src/main/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncer.java
+++ b/src/main/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncer.java
@@ -68,19 +68,18 @@ public final class TaxCategorySyncer
       @Nonnull final List<TaxCategory> page) {
     return CompletableFuture.completedFuture(
         page.stream()
-            .map(TaxCategorySyncer::convertTaxCaetegoryToTaxCategoryDraft)
+            .map(TaxCategorySyncer::convertTaxCategoryToTaxCategoryDraft)
             .collect(Collectors.toList()));
   }
 
   @Nonnull
-  private static TaxCategoryDraft convertTaxCaetegoryToTaxCategoryDraft(
+  private static TaxCategoryDraft convertTaxCategoryToTaxCategoryDraft(
       @Nonnull final TaxCategory taxCategory) {
     List<TaxRateDraft> taxRateDrafts = null;
-    if (taxCategory.getTaxRates() != null) {
-      taxRateDrafts = convertTaxRateToTaxRateDraft(taxCategory.getTaxRates());
-    }
+    taxRateDrafts = convertTaxRateToTaxRateDraft(taxCategory.getTaxRates());
     return TaxCategoryDraftBuilder.of(
             taxCategory.getName(), taxRateDrafts, taxCategory.getDescription())
+        .key(taxCategory.getKey())
         .build();
   }
 

--- a/src/test/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncerTest.java
+++ b/src/test/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncerTest.java
@@ -1,0 +1,82 @@
+package com.commercetools.project.sync.taxcategory;
+
+import static com.commercetools.project.sync.util.TestUtils.getMockedClock;
+import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.commercetools.sync.taxcategories.TaxCategorySync;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.TaxCategoryDraft;
+import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
+import io.sphere.sdk.taxcategories.TaxRateDraft;
+import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class TaxCategorySyncerTest {
+  @Test
+  void of_ShouldCreateTaxCategorySyncerInstance() {
+    // test
+    final TaxCategorySyncer taxCategorySyncer =
+        TaxCategorySyncer.of(mock(SphereClient.class), mock(SphereClient.class), getMockedClock());
+
+    // assertions
+    assertThat(taxCategorySyncer).isNotNull();
+    assertThat(taxCategorySyncer.getQuery()).isEqualTo(TaxCategoryQuery.of());
+    assertThat(taxCategorySyncer.getSync()).isInstanceOf(TaxCategorySync.class);
+  }
+
+  @Test
+  void transform_ShouldConvertResourcesToDrafts() {
+    // preparation
+    final TaxCategorySyncer taxCategorySyncer =
+        TaxCategorySyncer.of(mock(SphereClient.class), mock(SphereClient.class), getMockedClock());
+    final List<TaxCategory> taxCategoryPage =
+        asList(
+            readObjectFromResource("tax-category-key-1.json", TaxCategory.class),
+            readObjectFromResource("tax-category-key-2.json", TaxCategory.class));
+
+    // test
+    final CompletionStage<List<TaxCategoryDraft>> draftsFromPageStage =
+        taxCategorySyncer.transform(taxCategoryPage);
+
+    // assertions
+    assertThat(draftsFromPageStage)
+        .isCompletedWithValue(
+            taxCategoryPage
+                .stream()
+                .map(
+                    taxCategory -> {
+                      List<TaxRateDraft> taxRateDrafts =
+                          taxCategory
+                              .getTaxRates()
+                              .stream()
+                              .map(taxRate -> TaxRateDraftBuilder.of(taxRate).build())
+                              .collect(Collectors.toList());
+                      return TaxCategoryDraftBuilder.of(
+                          taxCategory.getName(), taxRateDrafts, taxCategory.getDescription());
+                    })
+                .map(TaxCategoryDraftBuilder::build)
+                .collect(toList()));
+  }
+
+  @Test
+  void getQuery_ShouldBuildTaxCategoryQuery() {
+    // preparation
+    final TaxCategorySyncer taxCategorySyncer =
+        TaxCategorySyncer.of(mock(SphereClient.class), mock(SphereClient.class), getMockedClock());
+
+    // test
+    final TaxCategoryQuery query = taxCategorySyncer.getQuery();
+
+    // assertion
+    assertThat(query).isEqualTo(TaxCategoryQuery.of());
+  }
+}

--- a/src/test/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncerTest.java
+++ b/src/test/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncerTest.java
@@ -61,7 +61,8 @@ class TaxCategorySyncerTest {
                               .map(taxRate -> TaxRateDraftBuilder.of(taxRate).build())
                               .collect(Collectors.toList());
                       return TaxCategoryDraftBuilder.of(
-                          taxCategory.getName(), taxRateDrafts, taxCategory.getDescription());
+                              taxCategory.getName(), taxRateDrafts, taxCategory.getDescription())
+                          .key(taxCategory.getKey());
                     })
                 .map(TaxCategoryDraftBuilder::build)
                 .collect(toList()));

--- a/src/test/resources/tax-category-key-1.json
+++ b/src/test/resources/tax-category-key-1.json
@@ -10,7 +10,16 @@
       "includedInPrice": true,
       "country": "US",
       "id": "ak80m7Jk",
-      "subRates": []
+      "subRates": [
+        {
+          "name": "sub-rate 01",
+          "amount": "0.05"
+        },
+        {
+          "name": "sub-rate 02",
+          "amount": "0.001"
+        }
+      ]
     },
     {
       "name": "19% MwSt test",
@@ -18,7 +27,16 @@
       "includedInPrice": false,
       "country": "DE",
       "id": "IZV0fDOU",
-      "subRates": []
+      "subRates": [
+        {
+          "name": "sub-rate 01",
+          "amount": "0.18"
+        },
+        {
+          "name": "sub-rate 02",
+          "amount": "0.01"
+        }
+      ]
     }
   ]
 }

--- a/src/test/resources/tax-category-key-1.json
+++ b/src/test/resources/tax-category-key-1.json
@@ -1,0 +1,24 @@
+{
+  "id": "44e5e889-0878-4c30-941f-767cebebeb7f",
+  "version": 18,
+  "name": "Standard tax category",
+  "key": "standard_tax_category_1",
+  "rates": [
+    {
+      "name": "5% US",
+      "amount": 0.051,
+      "includedInPrice": true,
+      "country": "US",
+      "id": "ak80m7Jk",
+      "subRates": []
+    },
+    {
+      "name": "19% MwSt test",
+      "amount": 0.19,
+      "includedInPrice": false,
+      "country": "DE",
+      "id": "IZV0fDOU",
+      "subRates": []
+    }
+  ]
+}

--- a/src/test/resources/tax-category-key-2.json
+++ b/src/test/resources/tax-category-key-2.json
@@ -10,7 +10,16 @@
       "includedInPrice": true,
       "country": "US",
       "id": "ak80m7Jk",
-      "subRates": []
+      "subRates": [
+        {
+          "name": "sub-rate 01",
+          "amount": "0.05"
+        },
+        {
+          "name": "sub-rate 02",
+          "amount": "0.001"
+        }
+      ]
     },
     {
       "name": "19% MwSt test",
@@ -18,7 +27,16 @@
       "includedInPrice": false,
       "country": "DE",
       "id": "IZV0fDOU",
-      "subRates": []
+      "subRates": [
+        {
+          "name": "sub-rate 01",
+          "amount": "0.18"
+        },
+        {
+          "name": "sub-rate 02",
+          "amount": "0.01"
+        }
+      ]
     }
   ]
 }

--- a/src/test/resources/tax-category-key-2.json
+++ b/src/test/resources/tax-category-key-2.json
@@ -1,0 +1,24 @@
+{
+  "id": "44e5e889-0878-4c30-941f-767cebebeb7f",
+  "version": 18,
+  "name": "Standard tax category",
+  "key": "standard_tax_category_2",
+  "rates": [
+    {
+      "name": "5% US",
+      "amount": 0.051,
+      "includedInPrice": true,
+      "country": "US",
+      "id": "ak80m7Jk",
+      "subRates": []
+    },
+    {
+      "name": "19% MwSt test",
+      "amount": 0.19,
+      "includedInPrice": false,
+      "country": "DE",
+      "id": "IZV0fDOU",
+      "subRates": []
+    }
+  ]
+}


### PR DESCRIPTION
- Create TaxCategorySyncer with extending Syncer class into  com.commercetools.project.sync.taxcategory package.
- Add unit test for TaxCategorySyncerTest (similar to TypeSyncerTest with 3 test of the Syncer class)