### PR TITLE
#164 implement custom object syncer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
     pmdVersion = '5.6.1'
     jacocoVersion = '0.7.9'
     findbugsVersion = '3.0.1'
-    commercetoolsSyncJava='2.0.0'
+    commercetoolsSyncJava='2.1.0'
     apacheCliVersion = '1.4'
     jupiterApiVersion = '5.7.0'
 }

--- a/src/main/java/com/commercetools/project/sync/Syncer.java
+++ b/src/main/java/com/commercetools/project/sync/Syncer.java
@@ -12,7 +12,7 @@ import com.commercetools.sync.commons.BaseSyncOptions;
 import com.commercetools.sync.commons.helpers.BaseSyncStatistics;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.customobjects.CustomObject;
-import io.sphere.sdk.models.Resource;
+import io.sphere.sdk.models.ResourceView;
 import io.sphere.sdk.queries.QueryDsl;
 import io.sphere.sdk.queries.QueryPredicate;
 import java.time.Clock;
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  *     com.commercetools.sync.categories.CategorySync}, etc..)
  */
 public abstract class Syncer<
-    T extends Resource,
+    T extends ResourceView,
     S,
     U extends BaseSyncStatistics,
     V extends BaseSyncOptions<T, S>,

--- a/src/main/java/com/commercetools/project/sync/customobject/CustomObjectSyncer.java
+++ b/src/main/java/com/commercetools/project/sync/customobject/CustomObjectSyncer.java
@@ -1,0 +1,135 @@
+package com.commercetools.project.sync.customobject;
+
+import static com.commercetools.project.sync.util.SyncUtils.logErrorCallback;
+import static com.commercetools.project.sync.util.SyncUtils.logWarningCallback;
+
+import com.commercetools.project.sync.Syncer;
+import com.commercetools.project.sync.service.CustomObjectService;
+import com.commercetools.project.sync.service.impl.CustomObjectServiceImpl;
+import com.commercetools.sync.commons.exceptions.SyncException;
+import com.commercetools.sync.commons.utils.QuadConsumer;
+import com.commercetools.sync.commons.utils.TriConsumer;
+import com.commercetools.sync.customobjects.CustomObjectSync;
+import com.commercetools.sync.customobjects.CustomObjectSyncOptions;
+import com.commercetools.sync.customobjects.CustomObjectSyncOptionsBuilder;
+import com.commercetools.sync.customobjects.helpers.CustomObjectCompositeIdentifier;
+import com.commercetools.sync.customobjects.helpers.CustomObjectSyncStatistics;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.customobjects.CustomObject;
+import io.sphere.sdk.customobjects.CustomObjectDraft;
+import io.sphere.sdk.customobjects.queries.CustomObjectQuery;
+import java.time.Clock;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class CustomObjectSyncer
+    extends Syncer<
+        CustomObject<JsonNode>,
+        CustomObjectDraft<JsonNode>,
+        CustomObjectSyncStatistics,
+        CustomObjectSyncOptions,
+        CustomObjectQuery<JsonNode>,
+        CustomObjectSync> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CustomObjectSyncer.class);
+
+  /**
+   * Instantiates a {@link Syncer} which is used to sync resources from a source to a target
+   * commercetools project.
+   *
+   * @param sync The sync module that is used for syncing the resource drafts to the target project,
+   *     after being transformed from the resources fetched from the source project.
+   * @param sourceClient the client used for querying data from the source commercetools project.
+   * @param targetClient the client used for syncing the transformed drafts into the target
+   *     commercetools project.
+   * @param customObjectService service that is used for fetching and persisting the last sync
+   *     timestamp for delta syncing.
+   * @param clock the clock to record the time for calculating the sync duration.
+   */
+  private CustomObjectSyncer(
+      @Nonnull CustomObjectSync sync,
+      @Nonnull SphereClient sourceClient,
+      @Nonnull SphereClient targetClient,
+      @Nonnull CustomObjectService customObjectService,
+      @Nonnull Clock clock) {
+    super(sync, sourceClient, targetClient, customObjectService, clock);
+  }
+
+  @Nonnull
+  @Override
+  protected CompletionStage<List<CustomObjectDraft<JsonNode>>> transform(
+      @Nonnull List<CustomObject<JsonNode>> page) {
+    final List<CustomObjectDraft<JsonNode>> collect =
+        page.stream()
+            .map(
+                customObject ->
+                    CustomObjectDraft.ofUnversionedUpsert(
+                        customObject.getContainer(),
+                        customObject.getKey(),
+                        customObject.getValue()))
+            .collect(Collectors.toList());
+    return CompletableFuture.completedFuture(collect);
+  }
+
+  @Nonnull
+  @Override
+  protected CustomObjectQuery<JsonNode> getQuery() {
+    // todo: exclude custom objects created by the project-sync from syncing
+    return CustomObjectQuery.ofJsonNode();
+  }
+
+  @Nonnull
+  public static CustomObjectSyncer of(
+      @Nonnull final SphereClient sourceClient,
+      @Nonnull final SphereClient targetClient,
+      @Nonnull final Clock clock) {
+    final QuadConsumer<
+            SyncException,
+            Optional<CustomObjectDraft<JsonNode>>,
+            Optional<CustomObject<JsonNode>>,
+            List<UpdateAction<CustomObject<JsonNode>>>>
+        logErrorCallback =
+            (exception, newResourceDraft, oldResource, updateActions) -> {
+              final String resourceIdentifier = getCustomObjectResourceIdentifier(oldResource);
+              updateActions = updateActions == null ? Collections.emptyList() : updateActions;
+              logErrorCallback(
+                  LOGGER, "customObject", exception, resourceIdentifier, updateActions);
+            };
+    final TriConsumer<
+            SyncException, Optional<CustomObjectDraft<JsonNode>>, Optional<CustomObject<JsonNode>>>
+        logWarningCallback =
+            (exception, newResourceDraft, oldResource) -> {
+              final String resourceIdentifier = getCustomObjectResourceIdentifier(oldResource);
+              logWarningCallback(LOGGER, "customObject", exception, resourceIdentifier);
+            };
+    final CustomObjectSyncOptions syncOptions =
+        CustomObjectSyncOptionsBuilder.of(targetClient)
+            .errorCallback(logErrorCallback)
+            .warningCallback(logWarningCallback)
+            .build();
+
+    final CustomObjectSync customObjectSyncer = new CustomObjectSync(syncOptions);
+
+    final CustomObjectService customObjectService = new CustomObjectServiceImpl(targetClient);
+
+    return new CustomObjectSyncer(
+        customObjectSyncer, sourceClient, targetClient, customObjectService, clock);
+  }
+
+  private static String getCustomObjectResourceIdentifier(
+      @Nonnull Optional<CustomObject<JsonNode>> oldResource) {
+    return oldResource
+        .map(CustomObjectCompositeIdentifier::of)
+        .map(CustomObjectCompositeIdentifier::toString)
+        .orElse("");
+  }
+}

--- a/src/test/java/com/commercetools/project/sync/customobject/CustomObjectSyncerTest.java
+++ b/src/test/java/com/commercetools/project/sync/customobject/CustomObjectSyncerTest.java
@@ -47,16 +47,16 @@ public class CustomObjectSyncerTest {
     when(customObject2.getContainer()).thenReturn("testContainer2");
     when(customObject2.getKey()).thenReturn("testKey2");
     when(customObject2.getValue()).thenReturn(JsonNodeFactory.instance.booleanNode(true));
-    final List<CustomObject<JsonNode>> drafts = asList(customObject1, customObject2);
+    final List<CustomObject<JsonNode>> customObjects = asList(customObject1, customObject2);
 
     // test
     final CompletionStage<List<CustomObjectDraft<JsonNode>>> draftsFromPageStage =
-        customObjectSyncer.transform(drafts);
+        customObjectSyncer.transform(customObjects);
 
     // assertions
     assertThat(draftsFromPageStage)
         .isCompletedWithValue(
-            drafts
+            customObjects
                 .stream()
                 .map(
                     customObject ->

--- a/src/test/java/com/commercetools/project/sync/customobject/CustomObjectSyncerTest.java
+++ b/src/test/java/com/commercetools/project/sync/customobject/CustomObjectSyncerTest.java
@@ -1,0 +1,82 @@
+package com.commercetools.project.sync.customobject;
+
+import static com.commercetools.project.sync.util.TestUtils.getMockedClock;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.commercetools.sync.customobjects.CustomObjectSync;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.customobjects.CustomObject;
+import io.sphere.sdk.customobjects.CustomObjectDraft;
+import io.sphere.sdk.customobjects.queries.CustomObjectQuery;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.Test;
+
+public class CustomObjectSyncerTest {
+
+  @Test
+  void of_ShouldCreateCustomObjectSyncerInstance() {
+    // test
+    final CustomObjectSyncer customObjectSyncer =
+        CustomObjectSyncer.of(mock(SphereClient.class), mock(SphereClient.class), getMockedClock());
+
+    // assertions
+    assertThat(customObjectSyncer).isNotNull();
+    assertThat(customObjectSyncer.getQuery()).isEqualTo(CustomObjectQuery.of(JsonNode.class));
+    assertThat(customObjectSyncer.getSync()).isExactlyInstanceOf(CustomObjectSync.class);
+  }
+
+  @Test
+  void transform_ShouldConvertResourcesToDrafts() {
+    // preparation
+    final CustomObjectSyncer customObjectSyncer =
+        CustomObjectSyncer.of(mock(SphereClient.class), mock(SphereClient.class), getMockedClock());
+
+    final CustomObject<JsonNode> customObject1 = mock(CustomObject.class);
+    when(customObject1.getContainer()).thenReturn("testContainer1");
+    when(customObject1.getKey()).thenReturn("testKey1");
+    when(customObject1.getValue()).thenReturn(JsonNodeFactory.instance.textNode("testValue1"));
+
+    final CustomObject<JsonNode> customObject2 = mock(CustomObject.class);
+    when(customObject2.getContainer()).thenReturn("testContainer2");
+    when(customObject2.getKey()).thenReturn("testKey2");
+    when(customObject2.getValue()).thenReturn(JsonNodeFactory.instance.booleanNode(true));
+    final List<CustomObject<JsonNode>> drafts = asList(customObject1, customObject2);
+
+    // test
+    final CompletionStage<List<CustomObjectDraft<JsonNode>>> draftsFromPageStage =
+        customObjectSyncer.transform(drafts);
+
+    // assertions
+    assertThat(draftsFromPageStage)
+        .isCompletedWithValue(
+            drafts
+                .stream()
+                .map(
+                    customObject ->
+                        CustomObjectDraft.ofUnversionedUpsert(
+                            customObject.getContainer(),
+                            customObject.getKey(),
+                            customObject.getValue()))
+                .collect(toList()));
+  }
+
+  @Test
+  void getQuery_ShouldBuildCustomObjectQuery() {
+    // preparation
+    final CustomObjectSyncer customObjectSyncer =
+        CustomObjectSyncer.of(mock(SphereClient.class), mock(SphereClient.class), getMockedClock());
+
+    // test
+    final CustomObjectQuery query = customObjectSyncer.getQuery();
+
+    // assertion
+    assertThat(query).isEqualTo(CustomObjectQuery.ofJsonNode());
+  }
+}


### PR DESCRIPTION
todo: exclude custom objects created by the project-sync from syncing - this will be included in the next PR.

As to the lower code coverage in this PR: the problem is the error and warning callbacks. They're quite hard to test and need extra time. Therefore, I will not address those issues in this PR, but in a different one.