### PR TITLE
#169 use UUID to generate random string for timestamp generator custom object

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Running a **Full sync** using `-f` or `--full` option will not create any `custo
 ##### Download
 
    ```bash
-docker pull commercetools/commercetools-project-sync:3.5.0
+docker pull commercetools/commercetools-project-sync:3.5.1
    ```
 ##### Run
 
@@ -156,14 +156,14 @@ docker run \
 -e TARGET_PROJECT_KEY=xxxx \
 -e TARGET_CLIENT_ID=xxxx \
 -e TARGET_CLIENT_SECRET=xxxx \
-commercetools/commercetools-project-sync:3.5.0 -s all
+commercetools/commercetools-project-sync:3.5.1 -s all
 ```
 
 
 ### Examples
  - To run the all sync modules from a source project to a target project
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s all
+   docker run commercetools/commercetools-project-sync:3.5.1 -s all
    ```
    This will run the following sync modules in the given order:
  1. `Type` Sync and `ProductType` Sync and `States` Sync and `TaxCategory` Sync and `CustomObject` Sync in parallel.
@@ -172,51 +172,51 @@ commercetools/commercetools-project-sync:3.5.0 -s all
 
  - To run the type sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s types
+   docker run commercetools/commercetools-project-sync:3.5.1 -s types
    ```
 
  - To run the productType sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s productTypes
+   docker run commercetools/commercetools-project-sync:3.5.1 -s productTypes
    ```
 
 - To run the states sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s states
+   docker run commercetools/commercetools-project-sync:3.5.1 -s states
    ```
 - To run the taxCategory sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s taxCategories
+   docker run commercetools/commercetools-project-sync:3.5.1 -s taxCategories
    ```
 
 - To run the category sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s categories
+   docker run commercetools/commercetools-project-sync:3.5.1 -s categories
    ```
 
 - To run the product sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s products
+   docker run commercetools/commercetools-project-sync:3.5.1 -s products
    ```
 
 - To run the cartDiscount sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s cartDiscounts
+   docker run commercetools/commercetools-project-sync:3.5.1 -s cartDiscounts
    ```
 
 - To run the inventoryEntry sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s inventoryEntries
+   docker run commercetools/commercetools-project-sync:3.5.1 -s inventoryEntries
    ```
 
 - To run the customObject sync
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s customObjects
+   docker run commercetools/commercetools-project-sync:3.5.1 -s customObjects
    ```
 
 - To run all sync modules using a runner name
    ```bash
-   docker run commercetools/commercetools-project-sync:3.5.0 -s all -r myRunnerName
+   docker run commercetools/commercetools-project-sync:3.5.1 -s all -r myRunnerName
    ```
 
 

--- a/src/integration-test/java/com/commercetools/project/sync/CliRunnerIT.java
+++ b/src/integration-test/java/com/commercetools/project/sync/CliRunnerIT.java
@@ -2,7 +2,6 @@ package com.commercetools.project.sync;
 
 import static com.commercetools.project.sync.service.impl.CustomObjectServiceImpl.DEFAULT_RUNNER_NAME;
 import static com.commercetools.project.sync.service.impl.CustomObjectServiceImpl.TIMESTAMP_GENERATOR_KEY;
-import static com.commercetools.project.sync.service.impl.CustomObjectServiceImpl.TIMESTAMP_GENERATOR_VALUE;
 import static com.commercetools.project.sync.util.ClientConfigurationUtils.createClient;
 import static com.commercetools.project.sync.util.IntegrationTestUtils.assertCategoryExists;
 import static com.commercetools.project.sync.util.IntegrationTestUtils.assertProductExists;
@@ -338,7 +337,9 @@ class CliRunnerIT {
         .hasOnlyOneElementSatisfying(
             currentCtpTimestamp -> {
               assertThat(currentCtpTimestamp.getKey()).isEqualTo(TIMESTAMP_GENERATOR_KEY);
-              assertThat(currentCtpTimestamp.getValue()).isEqualTo(TIMESTAMP_GENERATOR_VALUE);
+              assertThat(currentCtpTimestamp.getValue())
+                  .matches(
+                      "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}");
             });
 
     return currentCtpTimestampGeneratorResults.getResults().get(0).getLastModifiedAt();

--- a/src/main/java/com/commercetools/project/sync/service/impl/CustomObjectServiceImpl.java
+++ b/src/main/java/com/commercetools/project/sync/service/impl/CustomObjectServiceImpl.java
@@ -17,6 +17,7 @@ import io.sphere.sdk.queries.QueryPredicate;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -60,7 +61,7 @@ public class CustomObjectServiceImpl extends BaseServiceImpl implements CustomOb
 
     final CustomObjectDraft<String> currentTimestampDraft =
         CustomObjectDraft.ofUnversionedUpsert(
-            container, TIMESTAMP_GENERATOR_KEY, TIMESTAMP_GENERATOR_VALUE, String.class);
+            container, TIMESTAMP_GENERATOR_KEY, UUID.randomUUID().toString(), String.class);
 
     return createCustomObject(currentTimestampDraft).thenApply(ResourceView::getLastModifiedAt);
   }


### PR DESCRIPTION
We have to change the value of the timestamp generator custom object so it updates. Otherwise, the update will not happen and we will always get the same timestamp generator custom object. As we use its lastModifiedAt as a timestamp, the sync process will not work correctly.

Fixes: https://github.com/commercetools/commercetools-project-sync/issues/169

TODO: fix tests