### PR TITLE
209 - Add Error Callback tests for the Syncers

### DIFF
--- a/src/test/java/com/commercetools/project/sync/producttype/ProductTypeSyncerTest.java
+++ b/src/test/java/com/commercetools/project/sync/producttype/ProductTypeSyncerTest.java
@@ -5,20 +5,38 @@ import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.commercetools.sync.producttypes.ProductTypeSync;
 import com.commercetools.sync.producttypes.utils.ProductTypeReferenceResolutionUtils;
+import io.sphere.sdk.client.SphereApiConfig;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
 import io.sphere.sdk.producttypes.ProductTypeDraftBuilder;
 import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
+import io.sphere.sdk.queries.PagedQueryResult;
+import java.time.Clock;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.lidalia.slf4jtest.LoggingEvent;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 class ProductTypeSyncerTest {
+  private final TestLogger syncerTestLogger =
+      TestLoggerFactory.getTestLogger(ProductTypeSyncer.class);
+
+  @BeforeEach
+  void setup() {
+    syncerTestLogger.clearAll();
+  }
+
   @Test
   void of_ShouldCreateProductTypeSyncerInstance() {
     // test
@@ -66,5 +84,36 @@ class ProductTypeSyncerTest {
 
     // assertion
     assertThat(query).isEqualTo(ProductTypeReferenceResolutionUtils.buildProductTypeQuery(1));
+  }
+
+  @Test
+  void syncWithError_WhenNoKeyIsProvided_ShouldCallErrorCallback() {
+    // preparation
+    final SphereClient sourceClient = mock(SphereClient.class);
+    final SphereClient targetClient = mock(SphereClient.class);
+    when(sourceClient.getConfig()).thenReturn(SphereApiConfig.of("source-project"));
+    when(targetClient.getConfig()).thenReturn(SphereApiConfig.of("target-project"));
+
+    final List<ProductType> productTypePage =
+        asList(readObjectFromResource("product-type-without-key.json", ProductType.class));
+
+    final PagedQueryResult<ProductType> pagedQueryResult = mock(PagedQueryResult.class);
+    when(pagedQueryResult.getResults()).thenReturn(productTypePage);
+    when(sourceClient.execute(any(ProductTypeQuery.class)))
+        .thenReturn(CompletableFuture.completedFuture(pagedQueryResult));
+
+    // test
+    final ProductTypeSyncer productTypeSyncer =
+        ProductTypeSyncer.of(sourceClient, targetClient, mock(Clock.class));
+    productTypeSyncer.sync(null, true).toCompletableFuture().join();
+
+    // assertion
+    final LoggingEvent errorLog = syncerTestLogger.getAllLoggingEvents().get(0);
+    assertThat(errorLog.getMessage())
+        .isEqualTo(
+            "Error when trying to sync product type. Existing key: <<not present>>. Update actions: []");
+    assertThat(errorLog.getThrowable().get().getMessage())
+        .isEqualTo(
+            "ProductTypeDraft with name: main doesn't have a key. Please make sure all productType drafts have keys.");
   }
 }

--- a/src/test/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncerTest.java
+++ b/src/test/java/com/commercetools/project/sync/taxcategory/TaxCategorySyncerTest.java
@@ -5,22 +5,40 @@ import static io.sphere.sdk.json.SphereJsonUtils.readObjectFromResource;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.commercetools.sync.taxcategories.TaxCategorySync;
+import io.sphere.sdk.client.SphereApiConfig;
 import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.queries.PagedQueryResult;
 import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.taxcategories.TaxCategoryDraft;
 import io.sphere.sdk.taxcategories.TaxCategoryDraftBuilder;
 import io.sphere.sdk.taxcategories.TaxRateDraft;
 import io.sphere.sdk.taxcategories.TaxRateDraftBuilder;
 import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
+import java.time.Clock;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.lidalia.slf4jtest.LoggingEvent;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 class TaxCategorySyncerTest {
+  private final TestLogger syncerTestLogger =
+      TestLoggerFactory.getTestLogger(TaxCategorySyncer.class);
+
+  @BeforeEach
+  void setup() {
+    syncerTestLogger.clearAll();
+  }
+
   @Test
   void of_ShouldCreateTaxCategorySyncerInstance() {
     // test
@@ -79,5 +97,37 @@ class TaxCategorySyncerTest {
 
     // assertion
     assertThat(query).isEqualTo(TaxCategoryQuery.of());
+  }
+
+  @Test
+  void syncWithError_WhenNoKeyIsProvided_ShouldCallErrorCallback() {
+    // preparation
+    final SphereClient sourceClient = mock(SphereClient.class);
+    final SphereClient targetClient = mock(SphereClient.class);
+    when(sourceClient.getConfig()).thenReturn(SphereApiConfig.of("source-project"));
+    when(targetClient.getConfig()).thenReturn(SphereApiConfig.of("target-project"));
+
+    final List<TaxCategory> taxCategoryPage =
+        asList(readObjectFromResource("tax-category-without-key.json", TaxCategory.class));
+
+    final PagedQueryResult<TaxCategory> pagedQueryResult = mock(PagedQueryResult.class);
+    when(pagedQueryResult.getResults()).thenReturn(taxCategoryPage);
+    when(sourceClient.execute(any(TaxCategoryQuery.class)))
+        .thenReturn(CompletableFuture.completedFuture(pagedQueryResult));
+
+    // test
+    final TaxCategorySyncer taxCategorySyncer =
+        TaxCategorySyncer.of(sourceClient, targetClient, mock(Clock.class));
+    taxCategorySyncer.sync(null, true).toCompletableFuture().join();
+
+    // assertion
+    final LoggingEvent errorLog = syncerTestLogger.getAllLoggingEvents().get(0);
+    assertThat(errorLog.getMessage())
+        .isEqualTo(
+            "Error when trying to sync tax category. Existing key: <<not present>>. Update actions: []");
+    assertThat(errorLog.getThrowable().get().getMessage())
+        .isEqualTo(
+            "TaxCategoryDraft with name: Standard tax category doesn't have a key. "
+                + "Please make sure all tax category drafts have keys.");
   }
 }

--- a/src/test/resources/product-type-without-key.json
+++ b/src/test/resources/product-type-without-key.json
@@ -1,0 +1,25 @@
+{
+  "id": "cda0dbf7-b42e-40bf-8453-241d5b587f93",
+  "version": 46,
+  "name": "main",
+  "description": "all fleisch",
+  "classifier": "Complex",
+  "attributes": [
+    {
+      "name": "priceInfo",
+      "label": {
+        "en": "Grundpreis"
+      },
+      "isRequired": false,
+      "type": {
+        "name": "text"
+      },
+      "attributeConstraint": "SameForAll",
+      "isSearchable": true,
+      "inputHint": "SingleLine",
+      "displayGroup": "Other"
+    }
+  ],
+  "createdAt": "2015-06-09T08:51:37.052Z",
+  "lastModifiedAt": "2017-05-22T14:15:26.431Z"
+}

--- a/src/test/resources/state-without-key.json
+++ b/src/test/resources/state-without-key.json
@@ -1,0 +1,11 @@
+{
+  "type": "LineItemState",
+  "roles": [],
+  "name": {
+    "en": "State 1"
+  },
+  "description": {
+    "en": "State 1"
+  },
+  "initial": true
+}

--- a/src/test/resources/tax-category-without-key.json
+++ b/src/test/resources/tax-category-without-key.json
@@ -1,0 +1,24 @@
+{
+  "id": "44e5e889-0878-4c30-941f-767cebebeb7f",
+  "version": 18,
+  "name": "Standard tax category",
+  "rates": [
+    {
+      "name": "19% MwSt test",
+      "amount": 0.19,
+      "includedInPrice": false,
+      "country": "DE",
+      "id": "IZV0fDOU",
+      "subRates": [
+        {
+          "name": "sub-rate 01",
+          "amount": "0.18"
+        },
+        {
+          "name": "sub-rate 02",
+          "amount": "0.01"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/type-key-without-key.json
+++ b/src/test/resources/type-key-without-key.json
@@ -1,0 +1,26 @@
+{
+  "key": "1",
+  "name": {
+    "en": "name"
+  },
+  "description": {
+    "en": "description"
+  },
+  "resourceTypeIds": [
+    "category"
+  ],
+  "fieldDefinitions": [
+    {
+      "name": "a",
+      "label": {
+        "en": "label_en"
+      },
+      "required": false,
+      "type": {
+        "name": "String"
+      },
+      "inputHint": "SingleLine"
+    }
+  ]
+}
+

--- a/src/test/resources/type-without-key.json
+++ b/src/test/resources/type-without-key.json
@@ -1,7 +1,6 @@
 {
-  "key": "1",
   "name": {
-    "en": "name"
+    "en": "typeName"
   },
   "description": {
     "en": "description"


### PR DESCRIPTION
- Added tests for Error callbacks for the Syncers.

- Type
- TaxCategory
- State
- ProductType.

https://jira.commercetools.com/browse/CTPI-342

I tried to add Error callback for CustomObject, but It looks complicated, need some extra time. So skipped as part of this ticket.