### PR TITLE
New release preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Example:
 ##### Download
 
 ```bash
-docker pull commercetools/commercetools-project-sync:4.0.0
+docker pull commercetools/commercetools-project-sync:3.12.0
 ```
 ##### Run
 
@@ -209,14 +209,14 @@ docker run \
 -e TARGET_PROJECT_KEY=xxxx \
 -e TARGET_CLIENT_ID=xxxx \
 -e TARGET_CLIENT_SECRET=xxxx \
-commercetools/commercetools-project-sync:4.0.0 -s all
+commercetools/commercetools-project-sync:3.12.0 -s all
 ```
 
 
 ### Examples
  - To run the all sync modules from a source project to a target project
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s all
+   docker run commercetools/commercetools-project-sync:3.12.0 -s all
    ```
    This will run the following sync modules in the given order:
  1. `Type` Sync and `ProductType` Sync and `States` Sync and `TaxCategory` Sync and `CustomObject` Sync in parallel.
@@ -226,68 +226,68 @@ commercetools/commercetools-project-sync:4.0.0 -s all
 
  - To run the type sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s types
+   docker run commercetools/commercetools-project-sync:3.12.0 -s types
    ```
 
  - To run the productType sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s productTypes
+   docker run commercetools/commercetools-project-sync:3.12.0 -s productTypes
    ```
 
 - To run the states sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s states
+   docker run commercetools/commercetools-project-sync:3.12.0 -s states
    ```
 - To run the taxCategory sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s taxCategories
+   docker run commercetools/commercetools-project-sync:3.12.0 -s taxCategories
    ```
 
 - To run the category sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s categories
+   docker run commercetools/commercetools-project-sync:3.12.0 -s categories
    ```
 
 - To run the product sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s products
+   docker run commercetools/commercetools-project-sync:3.12.0 -s products
    ```
 
 - To run the cartDiscount sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s cartDiscounts
+   docker run commercetools/commercetools-project-sync:3.12.0 -s cartDiscounts
    ```
 
 - To run the inventoryEntry sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s inventoryEntries
+   docker run commercetools/commercetools-project-sync:3.12.0 -s inventoryEntries
    ```
 
 - To run the customObject sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s customObjects
+   docker run commercetools/commercetools-project-sync:3.12.0 -s customObjects
    ```
 
 - To run the customer sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s customers
+   docker run commercetools/commercetools-project-sync:3.12.0 -s customers
    ```
   
 - To run the shoppingList sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s shoppingLists
+   docker run commercetools/commercetools-project-sync:3.12.0 -s shoppingLists
    ```
 - To run both products and shoppingList sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s products shoppingLists
+   docker run commercetools/commercetools-project-sync:3.12.0 -s products shoppingLists
    ```
   
 - To run type, productType and shoppingList sync
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s types productTypes shoppingLists
+   docker run commercetools/commercetools-project-sync:3.12.0 -s types productTypes shoppingLists
    ```
 
 - To run all sync modules using a runner name
    ```bash
-   docker run commercetools/commercetools-project-sync:4.0.0 -s all -r myRunnerName
+   docker run commercetools/commercetools-project-sync:3.12.0 -s all -r myRunnerName
    ```


### PR DESCRIPTION
Prepare for the next release v3.12.0. Following is the draft of release note

**Enhancements**
* Migrate java version from java 1.8 to java 11
* Update prerequisite section in README.md since JDK installation is no longer necessary.

**Dependency Updates**
* `com.commercetools:commercetools-sync-java`: `4.0.0` -> `4.0.1`
* `com.fasterxml.jackson.dataformat:jackson-dataformat-cbor` : `2.11.4` -> `2.12.2`
* `io.netty:netty-codec-http`: `4.1.59.Final` -> `4.1.63.Final`
* `com.diffplug.spotless`: `5.11.0`-> `5.11.1`
* `org.asynchttpclient:async-http-client`  `2.12.2` -> `2.12.3`