### PR TITLE
Use the concurrency keyword to limit the ci concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: CI
+concurrency: CI
 
 on: [push]
 
@@ -11,12 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: serializing workflow runs
-        uses: softprops/turnstyle@v1
-        with:
-          same-branch-only: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Replacing turnstyle with concurrency.

Successfully tested that functionality on my project:

https://github.com/HollowMan6/LZU-Auto-COVID-Health-Report/blob/d23c4ac83fd5ae770595c1fda8ad1d66b7ceaa89/.github/workflows/autoreport.yml#L2

Test result: 
![20211001142530](https://user-images.githubusercontent.com/43995067/135576206-23dc5578-db81-4178-b561-52be242b97b2.png)
![20211001142544](https://user-images.githubusercontent.com/43995067/135576245-731259a1-6047-40ba-9573-ed8ce3c0e9b7.png)

Since I noticed that the `same-branch-only` is `false`, I didn't add `-${{ github.ref }}` in the group name.

Resolves #331 

Signed-off-by: Hollow Man <hollowman@hollowman.ml>