### PR TITLE
Change docker image distribution to eclipse temurin

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Build java classes
         run: ./gradlew setLibraryVersion assemble
       - name: Set up QEMU

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Build with Gradle
         run: ./gradlew clean setLibraryVersion build
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:11-jre
 LABEL maintainer="PS Team Munich [ps-dev@commercetools.com]"
 WORKDIR /app
 COPY ./build/libs libs/

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Example:
 ##### Download
 
 ```bash
-docker pull commercetools/commercetools-project-sync:5.2.2
+docker pull commercetools/commercetools-project-sync:5.3.0
 ```
 ##### Run
 
@@ -219,14 +219,14 @@ docker run \
 -e TARGET_PROJECT_KEY=xxxx \
 -e TARGET_CLIENT_ID=xxxx \
 -e TARGET_CLIENT_SECRET=xxxx \
-commercetools/commercetools-project-sync:5.2.2 -s all
+commercetools/commercetools-project-sync:5.3.0 -s all
 ```
 
 
 ### Examples
  - To run the all sync modules from a source project to a target project
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s all
+   docker run commercetools/commercetools-project-sync:5.3.0 -s all
    ```
    This will run the following sync modules in the given order:
  1. `Type` Sync and `ProductType` Sync and `States` Sync and `TaxCategory` Sync and `CustomObject` Sync in parallel.
@@ -236,68 +236,68 @@ commercetools/commercetools-project-sync:5.2.2 -s all
 
  - To run the type sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s types
+   docker run commercetools/commercetools-project-sync:5.3.0 -s types
    ```
 
  - To run the productType sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s productTypes
+   docker run commercetools/commercetools-project-sync:5.3.0 -s productTypes
    ```
 
 - To run the states sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s states
+   docker run commercetools/commercetools-project-sync:5.3.0 -s states
    ```
 - To run the taxCategory sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s taxCategories
+   docker run commercetools/commercetools-project-sync:5.3.0 -s taxCategories
    ```
 
 - To run the category sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s categories
+   docker run commercetools/commercetools-project-sync:5.3.0 -s categories
    ```
 
 - To run the product sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s products
+   docker run commercetools/commercetools-project-sync:5.3.0 -s products
    ```
 
 - To run the cartDiscount sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s cartDiscounts
+   docker run commercetools/commercetools-project-sync:5.3.0 -s cartDiscounts
    ```
 
 - To run the inventoryEntry sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s inventoryEntries
+   docker run commercetools/commercetools-project-sync:5.3.0 -s inventoryEntries
    ```
 
 - To run the customObject sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s customObjects
+   docker run commercetools/commercetools-project-sync:5.3.0 -s customObjects
    ```
 
 - To run the customer sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s customers
+   docker run commercetools/commercetools-project-sync:5.3.0 -s customers
    ```
   
 - To run the shoppingList sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s shoppingLists
+   docker run commercetools/commercetools-project-sync:5.3.0 -s shoppingLists
    ```
 - To run both products and shoppingList sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s products shoppingLists
+   docker run commercetools/commercetools-project-sync:5.3.0 -s products shoppingLists
    ```
   
 - To run type, productType and shoppingList sync
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s types productTypes shoppingLists
+   docker run commercetools/commercetools-project-sync:5.3.0 -s types productTypes shoppingLists
    ```
 
 - To run all sync modules using a runner name
    ```bash
-   docker run commercetools/commercetools-project-sync:5.2.2 -s all -r myRunnerName
+   docker run commercetools/commercetools-project-sync:5.3.0 -s all -r myRunnerName
    ```


### PR DESCRIPTION
**Situation**
Openjdk is deprecated, not updated anymore and it is recommended to replace it with another java distribution.

**Resolution**
- Change distribution described in docker file
- Update the distribution used for Java compiling in CI/CD
- Manually tested the docker image to synchronize dev projects in local machine
