### PR TITLE
DEVX-245 fix category syncer IT

### DIFF
--- a/src/test/java/com/commercetools/project/sync/SyncerFactoryTest.java
+++ b/src/test/java/com/commercetools/project/sync/SyncerFactoryTest.java
@@ -1020,9 +1020,10 @@ class SyncerFactoryTest {
         .withThrowableOfType(ExecutionException.class)
         .withCauseExactlyInstanceOf(RuntimeException.class)
         .satisfies(
-            exception -> assertThat(exception.getCause().getCause())
-                .isInstanceOf(BadGatewayException.class)
-                .hasMessageContaining("test"));
+            exception ->
+                assertThat(exception.getCause().getCause())
+                    .isInstanceOf(BadGatewayException.class)
+                    .hasMessageContaining("test"));
   }
 
   @Test

--- a/src/test/java/com/commercetools/project/sync/SyncerFactoryTest.java
+++ b/src/test/java/com/commercetools/project/sync/SyncerFactoryTest.java
@@ -1018,7 +1018,11 @@ class SyncerFactoryTest {
     assertThat(result)
         .failsWithin(1, TimeUnit.SECONDS)
         .withThrowableOfType(ExecutionException.class)
-        .withCauseExactlyInstanceOf(BadGatewayException.class);
+        .withCauseExactlyInstanceOf(RuntimeException.class)
+        .satisfies(
+            exception -> assertThat(exception.getCause().getCause())
+                .isInstanceOf(BadGatewayException.class)
+                .hasMessageContaining("test"));
   }
 
   @Test

--- a/src/test/java/com/commercetools/project/sync/service/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/project/sync/service/impl/CustomObjectServiceImplTest.java
@@ -198,8 +198,11 @@ class CustomObjectServiceImplTest {
     assertThat(lastSyncCustomObject)
         .failsWithin(Duration.ZERO)
         .withThrowableOfType(ExecutionException.class)
-        .withCauseExactlyInstanceOf(BadGatewayException.class)
-        .withMessageContaining("test");
+        .withCauseExactlyInstanceOf(RuntimeException.class)
+        .satisfies(
+            exception -> assertThat(exception.getCause().getCause())
+                .isInstanceOf(BadGatewayException.class)
+                .hasMessageContaining("test"));
   }
 
   @Test

--- a/src/test/java/com/commercetools/project/sync/service/impl/CustomObjectServiceImplTest.java
+++ b/src/test/java/com/commercetools/project/sync/service/impl/CustomObjectServiceImplTest.java
@@ -200,9 +200,10 @@ class CustomObjectServiceImplTest {
         .withThrowableOfType(ExecutionException.class)
         .withCauseExactlyInstanceOf(RuntimeException.class)
         .satisfies(
-            exception -> assertThat(exception.getCause().getCause())
-                .isInstanceOf(BadGatewayException.class)
-                .hasMessageContaining("test"));
+            exception ->
+                assertThat(exception.getCause().getCause())
+                    .isInstanceOf(BadGatewayException.class)
+                    .hasMessageContaining("test"));
   }
 
   @Test


### PR DESCRIPTION
JIRA: https://commercetools.atlassian.net/browse/DEVX-245

When last sync timestamp cannot be found, an exception is [being thrown in SDK v2.](https://github.com/commercetools/commercetools-project-sync/pull/514/files#diff-17d66f4b7138c576f6ded6878e09565ec5feecc0bd58df2076fcd66f65bd8706R84-R85) In the SDK v1, there was empty optional returned. Therefore I had to simulate the same behaviour. However, I need to catch other exceptions and rethrow. For this I had [to wrap in RuntimeException and rethrow](https://github.com/commercetools/commercetools-project-sync/pull/514/files#diff-17d66f4b7138c576f6ded6878e09565ec5feecc0bd58df2076fcd66f65bd8706R88) as there was no easy way just to rethrow the exception as is.

Because of the additional wrapping into `RuntimeException` I had to modify some tests as well.